### PR TITLE
Added user guidance principle & receive page details

### DIFF
--- a/pages/milestones/1-6-receive.md
+++ b/pages/milestones/1-6-receive.md
@@ -23,9 +23,22 @@ In this milestone we add features related to receiving.
 	height = 384
 %}
 
+#### Payment requests
+
+As described in the [principles]({{ '/principles/' | relative_url }}), the application is likely to be primarily used for higher-value payments. They are sensitive to users, so we want to ensure following best practices in transaction-related user flows is convenient.
+
+While sharing an address is technically the only piece of information needed to request bitcoin from another person, sharing a payment request with an amount and message, in the form of a BIP21 URI, is usually a more desirable user experience. Benefits are:
+- They can be clicked by the recipient. Operating systems will automatically open the most recently installed bitcoin wallets, open the send screen and prefill it with the provided information
+- Reduced risk of user errors in selecting, copying & pasting
+- Can include multiple addresses (like a silent payments and a regular address)
+- The contextual information can be stored in the sender and receivers wallets for future reference
+- Simplifies tracking by the user (e.g. seeing when a request has not been paid yet)
+
+While many bitcoin wallets only deal with addresses, we deliberately decided to continue supporting the payment request feature in the existing QT wallet.
+
 #### Creating requests
 
-At the center is the form to create new payment requests, which generates a new address with some user-defined payment information attached. One address per transaction is a best practice to improve privacy and for easier identification. Be aware of the note about label functionality at the bottom of this page.
+At the center is the form to create new payment requests, which generates a new address with some user-defined payment information attached. All fields are optional. One address per transaction is a best practice to improve privacy and for easier identification. Be aware of the note about label functionality at the bottom of this page.
 
 {% include picture.html
 	image = "/assets/images/receive/form.png"
@@ -35,6 +48,8 @@ At the center is the form to create new payment requests, which generates a new 
 	width = 800
 	height = 760
 %}
+
+Having an explicit step for user input results in multiple screens, but allows each one to be more simple and lets users focus on one task at a time.
 
 ##### Clarifying label functionality
 
@@ -50,7 +65,7 @@ Some examples might help clarify this:
 - Alice uses the label "Bob", so she can later tell that she shared the address and payment request with Bob. So Bob receives the payment request with his own name.
 - If Alice is aware of this and wants to ensure Bob knows who the payment request is from, she might use the label "Alice". This is helpful for Bob, but now Alice has an address that is labelled with her own name.
 
-That is why we split the label field in this design. One is attached to the address for personal reference, the other is shared with the payment request. The user can, for example, enter their name, so the recipient knows who the payment request is from.
+That is why we split the label field in this design. One is attached to the address for personal reference ("Note to self"), the other is shared with the payment request. The user can, for example, enter their name, so the recipient knows who the payment request is from.
 
 #### Viewing created requests
 
@@ -82,5 +97,12 @@ The application treats payment requests as not-yet-completed transactions, which
 #### Request history
 
 All requests the user has created are visible in the [activity]({{ '/milestones/1-5-activity/' | relative_url }}) screen.
+
+There are several benefits to users when payment requests and transactions are well annotated:
+
+- It is easier to keep an overview of their finances
+- Both sender and recipient have helpful context
+- Coin control and other privacy practices are easier to follow
+- The application can use the additional information to better support users
 
 The QT application treats payment requests almost as separate objects with their own screens for managing them. In this update, we try to blend them further and treat payment requests essentially as a type of transaction - one that is not completed yet. The screen that lists your own payment requests is removed, and that content is merged into the activity screen.

--- a/pages/principles.md
+++ b/pages/principles.md
@@ -9,6 +9,28 @@ nav_order: 5
 
 Design principles, or design philosophies, are helpful when making decisions large and small.
 
+## User guidance
+
+The bitcoin network comes with various technical and economic requirements. Due to the limited block space, transaction fees are relatively high. Fees have increased over time, as the network has found more use cases and users, and the fiat price of bitcoin has increased. This tendency is likely to continue.
+
+High fees mean that transactions below certain amounts are not economically viable. Paying 500 sats in fees for a 2,000 sat transaction is not appropriate. So the application is likely to be used for medium to high-value transactions, with a tendency towards high-value transactions as more time passes.
+
+Higher values are more meaningful and sensitive. Users have more anxiety around making mistakes and will do things like checking the accuracy of an address multiple times before sending.
+
+The application design should take this into consideration and ensure that users feel as comfortable and confident as possible. This can be achieved through means like clear communication of application activity, the use of clear and non-technical language, guidance towards best practices, and ensuring users understand the implications of their actions.
+
+## Simplicity with depth
+
+Oftentimes, application design struggles with the balance of simplicity for regular users with complexity for users who want more control. We can address this by intelligently layering the experience.
+
+1. The application should provide a "happy path" that is simple and convenient and allows the majority of users to quickly get started. Clear explanations that focus on the primary benefits and things to know, reducing options via smart defaults and recommendations, and good support when users get stuck are helpful here.
+
+2. The happy path should allow access to more in-depth settings and options, so users can go deeper if they want to. These should be fairly easy to access, but also easy to ignore, and not crucial to usage of the primary functions.
+
+3. To provide a great developer experience, certain settings and options should be accessible in a way that does not clutter up or distract the other paths, but allows developers to be effective. It is also helpful for designers to be able to launch an application in a certain state to evaluate the experience.
+
+We can embed this pattern in the basic UI architecture. The specific decisions as to which detail goes where will likely change over time as the application is refined with more user feedback. We may also decide to present users with different options based on whether they are on desktop or mobile. The pattern of having users choose between a "simple" and an "advanced" mode was considered, but decided against.
+
 ## [Accessibility]({{ '/accessibility/' | relative_url }})
 
 To allow as many people as possible to use the application, the design (and implementation) should be highly accessible. Getting these right can allow people in non-optimal situations to still successfully navigate and interact with bitcoin. This also includes supporting a broad range of device types and operating systems.
@@ -24,15 +46,3 @@ While a bitcoin wallet for children can be playful and creative, this applicatio
 ## Open design
 
 Just like the application code, the design is intended to be collaborated on openly and collaboratively. Design tools are not as sophisticated as development tools, so git-style collaboration is not possible. But we can still work with the tools we have and find workarounds for the gaps. For more, see [contribute]({{ '/contribute/' | relative_url }}).
-
-## Simplicity with depth
-
-Oftentimes, application design struggles with the balance of simplicity for regular users with complexity for users who want more control. We can address this by intelligently layering the experience.
-
-1. The application should provide a "happy path" that is simple and convenient and allows the majority of users to quickly get started. Clear explanations that focus on the primary benefits and things to know, reducing options via smart defaults and recommendations, and good support when users get stuck are helpful here.
-
-2. The happy path should allow access to more in-depth settings and options, so users can go deeper if they want to. These should be fairly easy to access, but also easy to ignore, and not crucial to usage of the primary functions.
-
-3. To provide a great developer experience, certain settings and options should be accessible in a way that does not clutter up or distract the other paths, but allows developers to be effective. It is also helpful for designers to be able to launch an application in a certain state to evaluate the experience.
-
-We can embed this pattern in the basic UI architecture. The specific decisions as to which detail goes where will likely change over time as the application is refined with more user feedback. We may also decide to present users with different options based on whether they are on desktop or mobile. The pattern of having users choose between a "simple" and an "advanced" mode was considered, but decided against.


### PR DESCRIPTION
Changes:
- New principle added about the rationale to guide users - the app being likely used for higher value transactions
- Added more rationale to the receive page based on this principle

We've having this long discussion around making the receive page more explicit rather than just giving people addresses. This update explains the rationale for that.