### PR TITLE
Add a features page

### DIFF
--- a/_sass/article.scss
+++ b/_sass/article.scss
@@ -5,7 +5,8 @@ article {
         line-height: 1.1;
         color: var(--neutral-9);
 
-        & + p {
+        & + p,
+        & + table {
             margin-top: 10px;
         }
 
@@ -87,7 +88,8 @@ article {
         & + h3,
         & + h4,
         & + h5,
-        & + h6 {
+        & + h6,
+        & + table {
             margin-top: 30px;
         }
     }
@@ -95,9 +97,11 @@ article {
     a {
         color: var(--neutral-9);
         text-decoration: underline;
+        text-decoration-color: rgba(var(--neutral-9-rgb), 0.25);
 
         &:hover {
             color: var(--primary);
+            text-decoration-color: var(--primary);
         }
     }
 
@@ -190,6 +194,53 @@ article {
 
         & + * {
             margin-top: 30px;
+        }
+    }
+
+    table {
+        border-collapse: collapse;
+        width: 100%;
+
+        thead tr th,
+        tbody tr td {
+            padding: 6px 8px;
+            border-collapse: collapse;
+            text-align: center;
+
+            &:first-child { text-align: left; }
+        }
+
+        thead {
+            tr {
+                th {
+                    font-weight: 600;
+
+                    &:first-child {
+                        text-align: left;
+                    }
+                }
+            }
+        }
+
+        tbody {
+            tr {
+                border-top: 1px solid var(--neutral-4);
+
+                td {
+                    color: var(--neutral-9);
+
+                    strong {
+                        font-weight: 600;
+                        color: var(--neutral-7);
+                        text-transform: uppercase;
+                        font-size: 15px;
+                    }
+                }
+
+                &:hover {
+                    background-color: var(--neutral-1);
+                }
+            }
         }
     }
 }

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -39,6 +39,7 @@ $fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, 'Helvetica Neue',
 	--neutral-7: #777777;
 	--neutral-8: #404040;
 	--neutral-9: #000000;
+	--neutral-9-rgb: 0, 0, 0;
 
 	--confirmations-1: #FF1C1C;
 	--confirmations-2: #ED6E46;
@@ -92,6 +93,7 @@ $fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, 'Helvetica Neue',
 	--neutral-7: #B0B0B0;
 	--neutral-8: #CCCCCC;
 	--neutral-9: #FFFFFF;
+	--neutral-9-rgb: 255, 255, 255;
 
 	--confirmations-1: #FF1C1C;
 	--confirmations-2: #ED6E46;

--- a/pages/features.md
+++ b/pages/features.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Features
+permalink: /features/
+nav_order: 1.5
+---
+
+# Features
+
+This page provides a list of features supported by the application, along with a comparison of feature supported by the QT application.
+
+**This is a complete work-in-progress.**
+
+| Feature                                                    | App     | QT      |
+| ---------------------------------------------------------- | ------- | ------- |
+| **First use**                                              |         |         |
+| Guided setup experience                                    | ✓       | ✗       |
+| **Sending**                                                |         |         |
+| Sending bitcoin                                            | ✓       | ?       |
+| [Multiple recipients]({{ '/1-7-send/' | relative_url }})   | ✓       | ?       |
+| Manual fee rate selection                                  | ✓       | ?       |
+| **Receiving**                                              |         |         |
+| Address labeling                                           | ✓       | ✓       |

--- a/pages/features.md
+++ b/pages/features.md
@@ -11,13 +11,59 @@ This page provides a list of features supported by the application, along with a
 
 **This is a complete work-in-progress.**
 
+### General
+
 | Feature                                                    | App     | QT      |
 | ---------------------------------------------------------- | ------- | ------- |
-| **First use**                                              |         |         |
 | Guided setup experience                                    | ✓       | ✗       |
-| **Sending**                                                |         |         |
+
+### Wallet management
+
+| Feature                                                    | App     | QT      |
+| ---------------------------------------------------------- | ------- | ------- |
+| Create single-key wallets                                  | ✓       | ?       |
+| Wallet file backup                                         | ✓       | ?       |
+| Wallet file import                                         | ✓       | ?       |
+| Password protection                                        | ✓       | ✓       |
+
+### [Sending]({{ '/1-7-send/' | relative_url }})
+
+| Feature                                                    | App     | QT      |
+| ---------------------------------------------------------- | ------- | ------- |
 | Sending bitcoin                                            | ✓       | ?       |
-| [Multiple recipients]({{ '/1-7-send/' | relative_url }})   | ✓       | ?       |
+| Amount input and "Send all"                                | ✓       | ?       |
+| Address input                                              | ✓       | ?       |
+| Priority-based fee options                                 | ✓       | ?       |
 | Manual fee rate selection                                  | ✓       | ?       |
-| **Receiving**                                              |         |         |
-| Address labeling                                           | ✓       | ✓       |
+| Multiple recipients                                        | ✓       | ?       |
+| Coin selection                                             | ✓       | ?       |
+| Contacts                                                   | ✓       | ?       |
+| Input & output visualization                               | ✓       | ?       |
+| PSBT import & export                                       | ✓       | ?       |
+| Import via clipboard                                       | ✓       | ?       |
+| Import via BIP-21 URI                                      | ✓       | ?       |
+| Single-key signing                                         | ✓       | ?       |
+| Replace-by-fee                                             | ✓       | ?       |
+| Include fee in amount                                      | ✓       | ?       |
+| External signer support                                    | ✓       | ?       |
+| Time locks                                                 | ✓       | ?       |
+| Review, sign & broadcast                                   | ✓       | ?       |
+
+### [Receiving]({{ '/1-6-receive/' | relative_url }})
+
+| Feature                                                    | App     | QT      |
+| ---------------------------------------------------------- | ------- | ------- |
+| Per transaction address generation                         | ✓       | ✓       | 
+| List of generated wallet addresses                         | ✓       | ✓       | 
+| Address labeling                                           | ✓       | ✓       | 
+| Payment request message                                    | ✓       | ✓       | 
+| Share via QR code                                          | ✓       | ✓       | 
+| Share via BIP-21 URI                                       | ✓       | ✓       | 
+
+### Node management
+
+### Settings
+
+| Feature                                                    | App     | QT      |
+| ---------------------------------------------------------- | ------- | ------- |
+| Create single-key wallets                                  | ✓       | ?       |

--- a/pages/features.md
+++ b/pages/features.md
@@ -5,65 +5,93 @@ permalink: /features/
 nav_order: 1.5
 ---
 
-# Features
-
-This page provides a list of features supported by the application, along with a comparison of feature supported by the QT application.
+# Planned features
 
 **This is a complete work-in-progress.**
+
+With this new application, we try to maintain all existing features from the QT application, while also making improvements and creating space for new features and future improvements. On this page you can find a list of features supported across both versions of the client.
+
+The page is called "Planned features", since the new application is under heavy development. "Planned" can mean everything across the feature lifecycle, from early exploration of late development. As development continues, we may change the scope of this page.
 
 ### General
 
 | Feature                                                    | App     | QT      |
 | ---------------------------------------------------------- | ------- | ------- |
-| Guided setup experience                                    | ✓       | ✗       |
+| Android support                                            | ✓       | ✗       |
+| Responsive screen layouts                                  | ✓       | ✗       |
+| [Guided setup experience]({{ '/first-use/' | relative_url }}) | ✓       | ✗       |
+| Message signing & verification                             | ✓       | ✓       |
 
 ### Wallet management
 
 | Feature                                                    | App     | QT      |
 | ---------------------------------------------------------- | ------- | ------- |
-| Create single-key wallets                                  | ✓       | ?       |
-| Wallet file backup                                         | ✓       | ?       |
-| Wallet file import                                         | ✓       | ?       |
+| Wallet switching                                           | ✓       | ✓       |
+| [Create single-key wallets]({{ '/1-4-create/' | relative_url }}) | ✓       | ✓       |
+| Create multi-key wallets                                   | ✓       | x       |
+| Descriptor wallets                                         | ✓       | ✓       |
+| Watch-only wallets                                         | ✓       | ✓       |
+| Wallet file backup                                         | ✓       | ✓       |
+| [Wallet file import]({{ '/1-3-import/' | relative_url }})  | ✓       | ✓       |
+| Encryption                                                 | ✓       | ✓       |
 | Password protection                                        | ✓       | ✓       |
 
 ### [Sending]({{ '/1-7-send/' | relative_url }})
 
 | Feature                                                    | App     | QT      |
 | ---------------------------------------------------------- | ------- | ------- |
-| Sending bitcoin                                            | ✓       | ?       |
-| Amount input and "Send all"                                | ✓       | ?       |
-| Address input                                              | ✓       | ?       |
-| Priority-based fee options                                 | ✓       | ?       |
-| Manual fee rate selection                                  | ✓       | ?       |
-| Multiple recipients                                        | ✓       | ?       |
-| Coin selection                                             | ✓       | ?       |
-| Contacts                                                   | ✓       | ?       |
-| Input & output visualization                               | ✓       | ?       |
-| PSBT import & export                                       | ✓       | ?       |
-| Import via clipboard                                       | ✓       | ?       |
-| Import via BIP-21 URI                                      | ✓       | ?       |
-| Single-key signing                                         | ✓       | ?       |
-| Replace-by-fee                                             | ✓       | ?       |
-| Include fee in amount                                      | ✓       | ?       |
-| External signer support                                    | ✓       | ?       |
-| Time locks                                                 | ✓       | ?       |
-| Review, sign & broadcast                                   | ✓       | ?       |
+| Sending bitcoin                                            | ✓       | ✓       |
+| "Send all" option                                          | ✓       | ✓       |
+| Legacy address support                                     | ✓       | ✓       |
+| Recommended fee rate                                       | ✓       | ✓       |
+| Priority-based fee options                                 | ✓       | ✗       |
+| Manual fee rate selection                                  | ✓       | ✓       |
+| Multiple recipients                                        | ✓       | ✓       |
+| Coin selection                                             | ✓       | ✓       |
+| Contacts                                                   | ✓       | ✓       |
+| Input & output visualization                               | ✓       | x       |
+| PSBT import & export                                       | ✓       | ✓       |
+| Import via clipboard                                       | ✓       | ✓       |
+| Import via BIP-21 URI                                      | ✓       | ✓       |
+| Single-key transaction signing                             | ✓       | ✓       |
+| Replace-by-fee                                             | ✓       | ✓       |
+| Include fee in amount                                      | ✓       | ✓       |
+| External signer support via HWI                            | ✓       | ✓       |
+| Time locks                                                 | ✓       | ✗       |
 
 ### [Receiving]({{ '/1-6-receive/' | relative_url }})
 
 | Feature                                                    | App     | QT      |
 | ---------------------------------------------------------- | ------- | ------- |
-| Per transaction address generation                         | ✓       | ✓       | 
-| List of generated wallet addresses                         | ✓       | ✓       | 
-| Address labeling                                           | ✓       | ✓       | 
-| Payment request message                                    | ✓       | ✓       | 
-| Share via QR code                                          | ✓       | ✓       | 
-| Share via BIP-21 URI                                       | ✓       | ✓       | 
+| Address generation                                         | ✓       | ✓       |
+| List of generated wallet addresses                         | ✓       | ✓       |
+| Address labeling                                           | ✓       | ✓       |
+| Address type selection                                     | ✓       | ✓       |
+| Payment request message                                    | ✓       | ✓       |
+| Share via QR code                                          | ✓       | ✓       |
+| Share via BIP-21 URI                                       | ✓       | ✓       |
+| Reusable addresses (Silent Payments)                       | ✓       | ✗       |
 
 ### Node management
+
+| Feature                                                    | App     | QT      |
+| ---------------------------------------------------------- | ------- | ------- |
+| [Network synchronization status]({{ '/block-clock/' | relative_url }}) | ✓       | ✓       |
+| Pruning                                                    | ✓       | ✓       |
+| Test networks                                              | ✓       | ✓       |
+| [Snapshot creation & import]({{ '/snapshot/' | relative_url }}) (assumeUTXO) | ✓       | x       |
+| Information screen                                         | ✓       | ✓       |
+| Console screen                                             | ✓       | ✓       |
+| Network traffic screen                                     | ✓       | ✓       |
+| Peers screen                                               | ✓       | ✓       |
 
 ### Settings
 
 | Feature                                                    | App     | QT      |
 | ---------------------------------------------------------- | ------- | ------- |
-| Create single-key wallets                                  | ✓       | ?       |
+| About screen                                               | ✓       | ✓       |
+| Application settings                                       | ✓       | ✓       |
+| Wallet settings                                            | ✓       | ✓       |
+| Network settings                                           | ✓       | ✓       |
+| Display settings                                           | ✓       | ✓       |
+| bitcoin.conf support                                       | ✓       | ✓       |

--- a/pages/features.md
+++ b/pages/features.md
@@ -9,7 +9,7 @@ nav_order: 1.5
 
 **This is a complete work-in-progress.**
 
-With this new application, we try to maintain all existing features from the QT application, while also making improvements and creating space for new features and future improvements. On this page you can find a list of features supported across both versions of the client.
+With the initial launch of this new application, we try to maintain feature parity with the QT application. Some options may be removed intentionally, and many options will be found in different places in the application. while also making improvements and creating space for new features and future improvements. On this page you can find a list of features supported across both versions of the client.
 
 The page is called "Planned features", since the new application is under heavy development. "Planned" can mean everything across the feature lifecycle, from early exploration of late development. As development continues, we may change the scope of this page.
 
@@ -18,7 +18,6 @@ The page is called "Planned features", since the new application is under heavy 
 | Feature                                                    | App     | QT      |
 | ---------------------------------------------------------- | ------- | ------- |
 | Android support                                            | ✓       | ✗       |
-| Responsive screen layouts                                  | ✓       | ✗       |
 | [Guided setup experience]({{ '/first-use/' | relative_url }}) | ✓       | ✗       |
 | Message signing & verification                             | ✓       | ✓       |
 
@@ -27,20 +26,20 @@ The page is called "Planned features", since the new application is under heavy 
 | Feature                                                    | App     | QT      |
 | ---------------------------------------------------------- | ------- | ------- |
 | Wallet switching                                           | ✓       | ✓       |
-| [Create single-key wallets]({{ '/1-4-create/' | relative_url }}) | ✓       | ✓       |
-| Create multi-key wallets                                   | ✓       | x       |
+| [Activity]({{ '/milestones/1-5-activity/' | relative_url }}) | ✓       | ✓       |
+| [Create single-key wallets]({{ '/milestones/1-4-create/' | relative_url }}) | ✓       | ✓       |
+| Create multi-key wallets                                   | ✓       | ✗       |
 | Descriptor wallets                                         | ✓       | ✓       |
 | Watch-only wallets                                         | ✓       | ✓       |
 | Wallet file backup                                         | ✓       | ✓       |
-| [Wallet file import]({{ '/1-3-import/' | relative_url }})  | ✓       | ✓       |
-| Encryption                                                 | ✓       | ✓       |
+| [Wallet file import]({{ '/milestones/1-3-import/' | relative_url }})  | ✓       | ✓       |
 | Password protection                                        | ✓       | ✓       |
 
-### [Sending]({{ '/1-7-send/' | relative_url }})
+### [Sending]({{ '/milestones/1-7-send/' | relative_url }})
 
 | Feature                                                    | App     | QT      |
 | ---------------------------------------------------------- | ------- | ------- |
-| Sending bitcoin                                            | ✓       | ✓       |
+| Transaction creation & broadcast                           | ✓       | ✓       |
 | "Send all" option                                          | ✓       | ✓       |
 | Legacy address support                                     | ✓       | ✓       |
 | Recommended fee rate                                       | ✓       | ✓       |
@@ -49,17 +48,17 @@ The page is called "Planned features", since the new application is under heavy 
 | Multiple recipients                                        | ✓       | ✓       |
 | Coin selection                                             | ✓       | ✓       |
 | Contacts                                                   | ✓       | ✓       |
-| Input & output visualization                               | ✓       | x       |
+| Input & output visualization                               | ✓       | ✗       |
 | PSBT import & export                                       | ✓       | ✓       |
 | Import via clipboard                                       | ✓       | ✓       |
 | Import via BIP-21 URI                                      | ✓       | ✓       |
-| Single-key transaction signing                             | ✓       | ✓       |
 | Replace-by-fee                                             | ✓       | ✓       |
 | Include fee in amount                                      | ✓       | ✓       |
+| Single-key transaction signing                             | ✓       | ✓       |
 | External signer support via HWI                            | ✓       | ✓       |
 | Time locks                                                 | ✓       | ✗       |
 
-### [Receiving]({{ '/1-6-receive/' | relative_url }})
+### [Receiving]({{ '/milestones/1-6-receive/' | relative_url }})
 
 | Feature                                                    | App     | QT      |
 | ---------------------------------------------------------- | ------- | ------- |
@@ -74,24 +73,23 @@ The page is called "Planned features", since the new application is under heavy 
 
 ### Node management
 
-| Feature                                                    | App     | QT      |
-| ---------------------------------------------------------- | ------- | ------- |
-| [Network synchronization status]({{ '/block-clock/' | relative_url }}) | ✓       | ✓       |
-| Pruning                                                    | ✓       | ✓       |
-| Test networks                                              | ✓       | ✓       |
-| [Snapshot creation & import]({{ '/snapshot/' | relative_url }}) (assumeUTXO) | ✓       | x       |
-| Information screen                                         | ✓       | ✓       |
-| Console screen                                             | ✓       | ✓       |
-| Network traffic screen                                     | ✓       | ✓       |
-| Peers screen                                               | ✓       | ✓       |
+| Feature                                                                         | App     | QT      |
+| ------------------------------------------------------------------------------- | ------- | ------- |
+| [Block synchronization status]({{ '/block-clock/' | relative_url }})            | ✓       | ✓       |
+| [Pruning]({{ '/settings/storage/' | relative_url }})                            | ✓       | ✓       |
+| [Snapshot creation & import]({{ '/snapshot/' | relative_url }}) (assumeUTXO)    | ✓       | ✗       |
+| [Network settings]({{ '/settings/network/' | relative_url }})                   | ✓       | ✓       |
+| Test networks                                                                   | ✓       | ✓       |
+| [Peers screen]({{ '/settings/peers/' | relative_url }})                         | ✓       | ✓       |
 
 ### Settings
 
-| Feature                                                    | App     | QT      |
-| ---------------------------------------------------------- | ------- | ------- |
-| About screen                                               | ✓       | ✓       |
-| Application settings                                       | ✓       | ✓       |
-| Wallet settings                                            | ✓       | ✓       |
-| Network settings                                           | ✓       | ✓       |
-| Display settings                                           | ✓       | ✓       |
-| bitcoin.conf support                                       | ✓       | ✓       |
+The structure of the settings has changed quite a bit. Almost all settings are still available, but have been moved to different screens, typically to be available contextually.
+
+| Feature                                                              | App     | QT      |
+| -------------------------------------------------------------------- | ------- | ------- |
+| [About screen]({{ '/settings/about/' | relative_url }})              | ✓       | ✓       |
+| [Display settings]({{ '/settings/display/' | relative_url }})        | ✓       | ✓       |
+| [Developer settings]({{ '/settings/developer/' | relative_url }})    | ✓       | ✗       |
+| [Console screen]({{ '/console/' | relative_url }})                   | ✓       | ✓       |
+| bitcoin.conf access                                                  | ✓       | ✓       |


### PR DESCRIPTION
Just want to get something going. It's a basic markdown table. Each row lists a feature. The name is a link to the respective place in the docs. The other two columns are to indicate support in the application and support in the QT application. Very simple. Content is total placeholder.

If we like this format, we can properly gather the table content. That will require input from multiple people, especially around which features are supported in QT.

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/c38cf981-6464-44f1-ae05-2072f8560b7a">

Closes #125